### PR TITLE
Network messages type not extending from IRangeMessage

### DIFF
--- a/src/types/chain/IRangeTransaction.ts
+++ b/src/types/chain/IRangeTransaction.ts
@@ -1,3 +1,5 @@
+import { IRangeMessage } from './IRangeMessage';
+
 export interface IKeyValuePair {
   key: string;
   value: string;
@@ -21,4 +23,5 @@ export interface IRangeTransaction {
   status: string;
   network: string;
   success: boolean;
+  messages: IRangeMessage[];
 }

--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -780,7 +780,8 @@ export interface CosmosHub4TrxMsgIbcCoreClientV1MsgSubmitMisbehaviour
 }
 
 // types for mgs type:: /ibc.core.client.v1.MsgUpdateClient
-export interface CosmosHub4TrxMsgIbcCoreClientV1MsgUpdateClient {
+export interface CosmosHub4TrxMsgIbcCoreClientV1MsgUpdateClient
+  extends IRangeMessage {
   type: CosmosHub4TrxMsgTypes.IbcCoreClientV1MsgUpdateClient;
   data: {
     '@type': string;

--- a/src/types/chain/grand-1/IRangeBlockGrand1TrxMsg.ts
+++ b/src/types/chain/grand-1/IRangeBlockGrand1TrxMsg.ts
@@ -470,7 +470,8 @@ export interface Grand1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
 }
 
 // types for mgs type:: /circle.cctp.v1.MsgAddRemoteTokenMessenger
-export interface Grand1TrxMsgCircleCctpV1MsgAddRemoteTokenMessenger {
+export interface Grand1TrxMsgCircleCctpV1MsgAddRemoteTokenMessenger
+  extends IRangeMessage {
   type: Grand1TrxMsgTypes.CircleCctpV1MsgAddRemoteTokenMessenger;
   data: {
     from: string;
@@ -507,7 +508,8 @@ export interface Grand1TrxMsgNobleFiatTokenFactoryMsgMint
 }
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
-export interface Grand1TrxMsgIbcCoreClientV1MsgCreateClient {
+export interface Grand1TrxMsgIbcCoreClientV1MsgCreateClient
+  extends IRangeMessage {
   type: Grand1TrxMsgTypes.IbcCoreClientV1MsgCreateClient;
   data: {
     '@type': string;

--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -100,7 +100,7 @@ export interface Noble1TrxMsgIbcCoreChannelV1MsgTimeout extends IRangeMessage {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgExec
-export interface Noble1TrxMsgCosmosAuthzV1beta1MsgExec {
+export interface Noble1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
   type: Noble1TrxMsgTypes.CosmosAuthzV1beta1MsgExec;
   data: {
     msgs: {

--- a/src/types/chain/osmo-test-5/IRangeBlockOsmoTest5TrxMsg.ts
+++ b/src/types/chain/osmo-test-5/IRangeBlockOsmoTest5TrxMsg.ts
@@ -798,7 +798,8 @@ export interface OsmoTest5TrxMsgOsmosisGammV1Beta1MsgJoinPool
 }
 
 // types for msg type:: /osmosis.gamm.v1beta1.MsgSwapExactAmountIn
-export interface OsmoTest5TrxMsgOsmosisGammV1beta1MsgSwapExactAmountIn {
+export interface OsmoTest5TrxMsgOsmosisGammV1beta1MsgSwapExactAmountIn
+  extends IRangeMessage {
   type: OsmoTest5TrxMsgTypes.OsmosisGammV1beta1MsgSwapExactAmountIn;
   data: {
     routes: Array<{ poolId: string; tokenOutDenom: string }>;
@@ -809,7 +810,8 @@ export interface OsmoTest5TrxMsgOsmosisGammV1beta1MsgSwapExactAmountIn {
 }
 
 // types for msg type:: /osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn
-export interface OsmoTest5TrxMsgOsmosisPoolManagerV1beta1MsgSwapExactAmountIn {
+export interface OsmoTest5TrxMsgOsmosisPoolManagerV1beta1MsgSwapExactAmountIn
+  extends IRangeMessage {
   type: OsmoTest5TrxMsgTypes.OsmosisPoolManagerV1beta1MsgSwapExactAmountIn;
   data: {
     routes: Array<{ poolId: string; tokenOutDenom: string }>;
@@ -820,7 +822,8 @@ export interface OsmoTest5TrxMsgOsmosisPoolManagerV1beta1MsgSwapExactAmountIn {
 }
 
 // types for msg type:: /osmosis.tokenfactory.v1beta1.MsgCreateDenom
-export interface OsmoTest5TrxMsgOsmosisTokenFactoryV1beta1MsgCreateDenom {
+export interface OsmoTest5TrxMsgOsmosisTokenFactoryV1beta1MsgCreateDenom
+  extends IRangeMessage {
   type: OsmoTest5TrxMsgTypes.OsmosisTokenFactoryV1beta1MsgCreateDenom;
   data: {
     sender: string;


### PR DESCRIPTION
## Summary

- Make `messages: IRangeMessage[];` as part of the `IRangeTransaction` interface. So message property is enforced by typing.
- Thanks to the previous point some of the network's messages showed they were not extending from the IRangeMessage interface.

## Why is this change needed?

When importing the interface to be used in a function as follows you can access the messages property by using the IRangeTransaction interface. The other way you need to directly import the network interface like (Noble1TrxMsg,  Osmosis1TrxMsg, ...) making the function less generic.

```js
export function filterTAMByAddresses(
  transactions: IRangeTransaction[],
  addresses: string[],
  success: boolean,
): IRangeTransaction[] {
   ....
  tx.messages
  ...
```

## Checks

- [x] Build