### PR TITLE
Types updated for block messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rangesecurity/range-sdk",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rangesecurity/range-sdk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rangesecurity/range-sdk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/types/IRangeAlertRule.ts
+++ b/src/types/IRangeAlertRule.ts
@@ -2,6 +2,8 @@ export interface IRangeAlertRule {
   id: string;
   ruleType: string;
   workspaceId?: string | null;
+  ruleGroupId: string;
+  network?: string;
   parameters: Record<string, unknown> | null;
   createdAt: Date;
   deletedAt?: Date | null;

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -79,6 +79,9 @@ export enum Osmosis1TrxMsgTypes {
   CosmosUpgradeV1beta1MsgSoftwareUpgrade = 'cosmos.upgrade.v1beta1.MsgSoftwareUpgrade',
   CosmwasmWasmV1MsgClearAdmin = 'cosmwasm.wasm.v1.MsgClearAdmin',
   CosmosBankV1beta1MsgUpdateParams = 'cosmos.bank.v1beta1.MsgUpdateParams',
+  OsmosisTokenFactoryV1betaBurn = 'osmosis.tokenfactory.v1beta1.MsgBurn',
+  OsmosisTokenFactoryV1beta1MsgChangeAdmin = 'osmosis.tokenfactory.v1beta1.MsgChangeAdmin',
+  OsmosisTokenFactoryV1beta1MsgSetDenomMetadata = 'osmosis.tokenfactory.v1beta1.MsgSetDenomMetadata',
 }
 
 export type Osmosis1TrxMsg =
@@ -159,7 +162,8 @@ export type Osmosis1TrxMsg =
   | Osmosis1TrxMsgCosmosUpgradeV1beta1MsgCancelUpgrade
   | Osmosis1TrxMsgCosmosUpgradeV1beta1MsgSoftwareUpgrade
   | Osmosis1TrxMsgCosmwasmWasmV1MsgClearAdmin
-  | Osmosis1TrxMsgCosmosBankV1beta1MsgUpdateParams;
+  | Osmosis1TrxMsgCosmosBankV1beta1MsgUpdateParams
+  | Osmosis1TrxMsgOsmosisTokenFactoryV1betaBurn;
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
 export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
@@ -1457,6 +1461,54 @@ export interface Osmosis1TrxMsgCosmosBankV1beta1MsgUpdateParams
         enabled: string;
       }[];
       default_send_enabled: boolean;
+    };
+  };
+}
+
+// types for msg type:: /osmosis.tokenfactory.v1beta1.MsgBurn
+export interface Osmosis1TrxMsgOsmosisTokenFactoryV1betaBurn
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.OsmosisTokenFactoryV1betaBurn;
+  data: {
+    sender: string;
+    amount: {
+      denom: string;
+      amount: string;
+    };
+    burnFromAddress: string;
+  };
+}
+
+// types for msg type:: /osmosis.tokenfactory.v1beta1.MsgChangeAdmin
+export interface Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgChangeAdmin
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.OsmosisTokenFactoryV1beta1MsgChangeAdmin;
+  data: {
+    sender: string;
+    denom: string;
+    new_admin: string;
+  };
+}
+
+// types for msg type:: /osmosis.tokenfactory.v1beta1.MsgChangeAdmin
+export interface Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.OsmosisTokenFactoryV1beta1MsgSetDenomMetadata;
+  data: {
+    sender: string;
+    metadata: {
+      description: string;
+      denom_units: {
+        denom: string;
+        exponent: number;
+        aliases: string;
+      }[];
+      base: string;
+      display: string;
+      name: string;
+      symbol: string;
+      uri: string;
+      uri_hash: string;
     };
   };
 }

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -163,7 +163,9 @@ export type Osmosis1TrxMsg =
   | Osmosis1TrxMsgCosmosUpgradeV1beta1MsgSoftwareUpgrade
   | Osmosis1TrxMsgCosmwasmWasmV1MsgClearAdmin
   | Osmosis1TrxMsgCosmosBankV1beta1MsgUpdateParams
-  | Osmosis1TrxMsgOsmosisTokenFactoryV1betaBurn;
+  | Osmosis1TrxMsgOsmosisTokenFactoryV1betaBurn
+  | Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgChangeAdmin
+  | Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata;
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
 export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {


### PR DESCRIPTION
**Changelog**

- enhance: types updated for osmosis-1 message types
- fix: Osmosis1TrxMsg updated to include missing messages Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgChangeAdmin and Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata
- fix: IRangeAlertRule type updated to include network and ruleGroupId