### PR TITLE
fix: set group ids for kafka consumers from config fetched from manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@range-security/range-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "private": false,
   "scripts": {
     "build": "tsc --esModuleInterop --resolveJsonModule --declaration",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@range-security/range-sdk",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -66,14 +66,14 @@ class RangeSDK implements IRangeSDK {
     const kafka = new Kafka(this.config.kafka);
     this.blockRuleGroupTaskClient = new KafkaConsumerClient(
       kafka,
-      `rangeSDK-runner-${this.runnerId}-block-rule-group-task`,
+      this.config.kafkaGroupIds.blockRuleGroupTasks,
       {
         retries: 3,
       },
     );
     this.errorBlockRuleTaskClient = new KafkaConsumerClient(
       kafka,
-      `rangeSDK-runner-${this.runnerId}-error-block-rule-task`,
+      this.config.kafkaGroupIds.errorsBlockRuleTasks,
       {
         retries: 0,
       },

--- a/src/types/IRangeConfig.ts
+++ b/src/types/IRangeConfig.ts
@@ -6,4 +6,8 @@ export interface IRangeConfig {
     blockRuleGroupTasks: string;
     errorsBlockRuleTasks: string;
   };
+  kafkaGroupIds: {
+    blockRuleGroupTasks: string;
+    errorsBlockRuleTasks: string;
+  };
 }


### PR DESCRIPTION
**Changelog**

- fix: update the licence name in package.json
- fix: set group ids for kafka consumers from config fetched from manager