### PR TITLE
fix: types for BlockBase updated to include block_events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@range-security/range-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/types/chain/IRangeBlock.ts
+++ b/src/types/chain/IRangeBlock.ts
@@ -15,7 +15,8 @@ interface BlockBase {
   transactions: IRangeTransaction[];
   network: NetworkEnum;
   timestamp: string;
-  block_data?: string;
+  block_data?: Record<string | number | symbol, unknown>;
+  block_events?: Record<string | number | symbol, unknown>;
 }
 
 export interface Osmosis1Block extends BlockBase {


### PR DESCRIPTION
**Changelog**

- fix: types for BlockBase updated to include block_events