### PR TITLE
[RNG-520]: test sdk updated to route back available range of blocks when requested block is not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@range-security/range-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@range-security/range-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "SDK for easy custom alerts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/test-sdk.ts
+++ b/src/test-sdk.ts
@@ -37,6 +37,7 @@ class TestRangeSDK implements IRangeSDK {
       token: this.opts.token,
       height: args.height,
       network: args.network,
+      includeAvailableRangeOnNotFound: true,
     });
   }
 


### PR DESCRIPTION
**Changelog**

- enhance: test sdk updated to route back available range of blocks when requested block is not found

**Prerequisites**

1. Merge and deploy https://github.com/rangesecurity/manager/pull/9

**Postrequisites**

- [ ] Publish the new version `1.2.1`