### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -426,23 +426,26 @@ export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode
 }
 
 // types for mgs type:: /ibc.applications.transfer.v1.MsgTransfer
-export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer {
-    type: string;
-    data: Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferData;
-}
-interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferData {
+export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcApplicationsTransferV1MsgTransfer;
+  data: {
     sourcePort: string;
     sourceChannel: string;
-    token: Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferToken;
+    token: {
+      denom: string;
+      amount: string;
+    };
     sender: string;
     receiver: string;
-    timeoutTimestamp: string;
+    timeoutHeight?: {
+      revisionNumber?: string;
+      revisionHeight?: string;
+    };
+    timeoutTimestamp?: string;
+    memo?: string;
+  };
 }
-interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferToken {
-    denom: string;
-    amount: string;
-}
-
 
 // types for mgs type:: /ibc.core.channel.v1.MsgAcknowledgement
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgAcknowledgement

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -426,25 +426,23 @@ export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode
 }
 
 // types for mgs type:: /ibc.applications.transfer.v1.MsgTransfer
-export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcApplicationsTransferV1MsgTransfer;
-  data: {
+export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer {
+    type: string;
+    data: Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferData;
+}
+interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferData {
     sourcePort: string;
     sourceChannel: string;
-    token: {
-      denom: string;
-      amount: string;
-    };
+    token: Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferToken;
     sender: string;
     receiver: string;
-    timeoutHeight: {
-      revisionNumber: string;
-      revisionHeight: string;
-    };
-    timeoutTimestamp?: string;
-  };
+    timeoutTimestamp: string;
 }
+interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransferToken {
+    denom: string;
+    amount: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgAcknowledgement
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgAcknowledgement


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer
    
**Block Data**
network: osmosis-1
height: 12915074
data:
```
[
  {
    "sourcePort": "transfer",
    "sourceChannel": "channel-320",
    "token": {
      "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
      "amount": "137000000"
    },
    "sender": "osmo10ql2xwk5jplam4dpaef4l2v8ftsl6f4jhn4kd6",
    "receiver": "agoric1ykcxyp5d8ry64uc65rgve8jm9mn3x3rgqnwtz9",
    "timeoutTimestamp": "1703400025849000000"
  }
]
```
