### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -1161,38 +1161,32 @@ export interface Osmosis1TrxMsgOsmosisValsetprefV1beta1MsgWithdrawDelegationRewa
   };
 }
 
-// types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator {
-    type: string;
-    data: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData {
-    description: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription;
-    commission: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission;
+// types for mgs type:: /cosmos.staking.v1beta1.MsgCreateValidator
+export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.CosmosStakingV1beta1MsgCreateValidator;
+  data: {
+    description: {
+      details?: string;
+      moniker: string;
+      identity?: string;
+      securityContact?: string;
+    };
+    commission: {
+      rate: string;
+      maxRate: string;
+      maxChangeRate: string;
+    };
     minSelfDelegation: string;
     delegatorAddress: string;
     validatorAddress: string;
-    pubkey: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey;
-    value: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue;
+    pubkey: {
+      key: string;
+      '@type': string;
+    };
+    value: { denom: string; amount: string };
+  };
 }
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription {
-    moniker: string;
-    securityContact: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission {
-    rate: string;
-    maxRate: string;
-    maxChangeRate: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey {
-    '@type': string;
-    key: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue {
-    denom: string;
-    amount: string;
-}
-
 
 // types for mgs type:: /cosmos.distribution.v1beta1.MsgFundCommunityPool
 export interface Osmosis1TrxMsgCosmosDistributionV1beta1MsgFundCommunityPool

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -1162,30 +1162,37 @@ export interface Osmosis1TrxMsgOsmosisValsetprefV1beta1MsgWithdrawDelegationRewa
 }
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.CosmosStakingV1beta1MsgCreateValidator;
-  data: {
-    value: { denom: string; amount: string };
-    pubkey: {
-      key: string;
-      '@type': string;
-    };
-    commission: {
-      rate: string;
-      maxRate: string;
-      maxChangeRate: string;
-    };
-    description: {
-      details: string;
-      moniker: string;
-      identity: string;
-    };
+export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator {
+    type: string;
+    data: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData {
+    description: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription;
+    commission: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission;
+    minSelfDelegation: string;
     delegatorAddress: string;
     validatorAddress: string;
-    minSelfDelegation: string;
-  };
+    pubkey: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey;
+    value: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue;
 }
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription {
+    moniker: string;
+    securityContact: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission {
+    rate: string;
+    maxRate: string;
+    maxChangeRate: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey {
+    '@type': string;
+    key: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue {
+    denom: string;
+    amount: string;
+}
+
 
 // types for mgs type:: /cosmos.distribution.v1beta1.MsgFundCommunityPool
 export interface Osmosis1TrxMsgCosmosDistributionV1beta1MsgFundCommunityPool


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
    
**Block Data**
network: osmosis-1
height: 12949174
data:
```
[
  {
    "description": {
      "moniker": "d3akash.cloud",
      "securityContact": "info@d3akash.cloud"
    },
    "commission": {
      "rate": "100000000000000000",
      "maxRate": "200000000000000000",
      "maxChangeRate": "10000000000000000"
    },
    "minSelfDelegation": "1",
    "delegatorAddress": "osmo1u5cdg7k3gl43mukca4aeultuz8x2j68mdwdag3",
    "validatorAddress": "osmovaloper1u5cdg7k3gl43mukca4aeultuz8x2j68mhe97lk",
    "pubkey": {
      "@type": "/cosmos.crypto.ed25519.PubKey",
      "key": "wXYUKSxoJZSA3QOSyOpVmnYcO2HV2iD8ZnvoNbxuU70="
    },
    "value": {
      "denom": "uosmo",
      "amount": "1000000"
    }
  }
]
```
