### PR TITLE
[auto-fix] interface type updated for CelestiaTrxMsgIbcCoreClientV1MsgUpdateClient

### DIFF
--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -614,99 +614,97 @@ export interface CelestiaTrxMsgIbcCoreClientV1MsgCreateClient
 }
 
 // types for msg type: /ibc.core.client.v1.MsgUpdateClient
-export interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClient
-  extends IRangeMessage {
-  type: CelestiaTrxMsgTypes.IbcCoreClientV1MsgUpdateClient;
-  data: {
+export interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClient {
+    type: string;
+    data: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientData;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientData {
     signer: string;
     clientId: string;
-    clientMessage: {
-      '@type': string;
-      signedHeader: {
-        commit: {
-          round: number;
-          height: string;
-          blockId: {
-            hash: string;
-            partSetHeader: {
-              hash: string;
-              total: number;
-            };
-          };
-          signatures: {
-            blockIdFlag: string;
-            signature?: string;
-            timestamp?: string;
-            validatorAddress?: string;
-          }[];
-        };
-        header: {
-          time: string;
-          height: string;
-          appHash: string;
-          chainId: string;
-          version: {
-            app: string;
-            block: string;
-          };
-          dataHash: string;
-          lastBlockId: {
-            hash: string;
-            partSetHeader: {
-              hash: string;
-              total: number;
-            };
-          };
-          evidenceHash: string;
-          consensusHash: string;
-          lastCommitHash: string;
-          validatorsHash: string;
-          lastResultsHash: string;
-          proposerAddress: string;
-          nextValidatorsHash: string;
-        };
-      };
-      validatorSet: {
-        proposer: {
-          pubKey: {
-            ed25519: string;
-          };
-          address: string;
-          votingPower: string;
-        };
-        validators: {
-          pubKey: {
-            ed25519: string;
-          };
-          address: string;
-          votingPower: string;
-        }[];
-        totalVotingPower: string;
-      };
-      trustedHeight: {
-        revisionHeight: string;
-        revisionNumber: string;
-      };
-      trustedValidators: {
-        proposer: {
-          pubKey: {
-            ed25519: string;
-          };
-          address: string;
-          votingPower: string;
-        };
-        validators: {
-          pubKey: {
-            ed25519: string;
-          };
-          address: string;
-          votingPower: string;
-        }[];
-        totalVotingPower: string;
-      };
-    };
-  };
+    clientMessage: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientClientMessage;
 }
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientClientMessage {
+    '@type': string;
+    signedHeader: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientSignedHeader;
+    validatorSet: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientValidatorSet;
+    trustedHeight: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientTrustedHeight;
+    trustedValidators: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientTrustedValidators;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientSignedHeader {
+    commit: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientCommit;
+    header: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientHeader;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientCommit {
+    height: string;
+    blockId: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientBlockId;
+    signatures: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientSignaturesItem[];
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientBlockId {
+    hash: string;
+    partSetHeader: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPartSetHeader;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPartSetHeader {
+    hash: string;
+    total: number;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientSignaturesItem {
+    signature?: string;
+    timestamp: string;
+    blockIdFlag: string;
+    validatorAddress?: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientHeader {
+    time: string;
+    height: string;
+    appHash: string;
+    chainId: string;
+    version: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientVersion;
+    dataHash: string;
+    lastBlockId: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientLastBlockId;
+    evidenceHash: string;
+    consensusHash: string;
+    lastCommitHash: string;
+    validatorsHash: string;
+    lastResultsHash: string;
+    proposerAddress: string;
+    nextValidatorsHash: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientVersion {
+    app: string;
+    block: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientLastBlockId {
+    hash: string;
+    partSetHeader: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPartSetHeader;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientValidatorSet {
+    proposer: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientProposer;
+    validators: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientValidatorsItem[];
+    totalVotingPower: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientProposer {
+    pubKey: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPubKey;
+    address: string;
+    votingPower: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPubKey {
+    ed25519: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientValidatorsItem {
+    pubKey: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientPubKey;
+    address: string;
+    votingPower: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientTrustedHeight {
+    revisionHeight: string;
+    revisionNumber: string;
+}
+interface CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientTrustedValidators {
+    proposer: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientProposer;
+    validators: CelestiaTrxMsgIbcCoreClientV1MsgUpdateClientValidatorsItem[];
+    totalVotingPower: string;
+}
+
 
 // types for msg type: /ibc.core.connection.v1.MsgConnectionOpenAck
 export interface CelestiaTrxMsgIbcCoreConnectionV1MsgConnectionOpenAck


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CelestiaTrxMsgIbcCoreClientV1MsgUpdateClient
    
**Block Data**
network: celestia
height: 411041
