### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -508,30 +508,33 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenTry;
-  data: {
-    portId: string;
-    signer: string;
-    channel: {
-      state: string;
-      version: string;
-      ordering: string;
-      counterparty: {
-        portId: string;
-        channelId: string;
-      };
-      connectionHops: string[];
-    };
-    proofInit: string;
-    proofHeight: {
-      revisionHeight: string;
-      revisionNumber: string;
-    };
-    counterpartyVersion: string;
-  };
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry {
+    type: string;
+    data: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryData;
 }
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryData {
+    portId: string;
+    channel: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel;
+    counterpartyVersion: string;
+    proofInit: string;
+    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight;
+    signer: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel {
+    state: string;
+    ordering: string;
+    counterparty: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty;
+    connectionHops: string[];
+    version: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty {
+    portId: string;
+    channelId: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight {
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -508,33 +508,30 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry {
-    type: string;
-    data: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryData;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryData {
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenTry;
+  data: {
     portId: string;
-    channel: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel;
+    channel: {
+      state: string;
+      ordering: string;
+      counterparty: {
+        portId: string;
+        channelId: string;
+      };
+      connectionHops: string[];
+      version: string;
+    };
     counterpartyVersion: string;
     proofInit: string;
-    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight;
+    proofHeight: {
+      revisionHeight: string;
+      revisionNumber?: string;
+    };
     signer: string;
+  };
 }
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel {
-    state: string;
-    ordering: string;
-    counterparty: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty;
-    connectionHops: string[];
-    version: string;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty {
-    portId: string;
-    channelId: string;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight {
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry
    
**Block Data**
network: osmosis-1
height: 13076702
