### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -492,21 +492,20 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelCloseConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenConfirm
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm {
-    type: string;
-    data: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmData;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmData {
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenConfirm;
+  data: {
     portId: string;
     channelId: string;
     proofAck: string;
-    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmProofHeight;
+    proofHeight: {
+      revisionHeight: string;
+      revisionNumber?: string;
+    };
     signer: string;
+  };
 }
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmProofHeight {
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -492,20 +492,21 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelCloseConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenConfirm
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenConfirm;
-  data: {
-    portId: string;
-    signer: string;
-    proofAck: string;
-    channelId: string;
-    proofHeight: {
-      revisionHeight: string;
-      revisionNumber: string;
-    };
-  };
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm {
+    type: string;
+    data: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmData;
 }
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmData {
+    portId: string;
+    channelId: string;
+    proofAck: string;
+    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmProofHeight;
+    signer: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirmProofHeight {
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
    
**Block Data**
network: osmosis-1
height: 13076706
