### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgIbcCoreChannelV1MsgTimeout

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -173,32 +173,35 @@ export interface Neutron1TrxMsgIbcCoreChannelV1MsgRecvPacket
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
-export interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeout
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.IbcCoreChannelV1MsgTimeout;
-  data: {
-    packet: {
-      data: string;
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      timeoutHeight: {
-        revisionHeight?: string;
-        revisionNumber?: string;
-      };
-      destinationPort: string;
-      timeoutTimestamp: string;
-      destinationChannel: string;
-    };
-    signer: string;
-    proofHeight: {
-      revisionHeight?: string;
-      revisionNumber?: string;
-    };
-    proofUnreceived: string;
-    nextSequenceRecv: string;
-  };
+export interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeout {
+    type: string;
+    data: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutData;
 }
+interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutData {
+    packet: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutPacket;
+    proofUnreceived: string;
+    proofHeight: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight;
+    nextSequenceRecv: string;
+    signer: string;
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight;
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
 export interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClient

--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -173,35 +173,32 @@ export interface Neutron1TrxMsgIbcCoreChannelV1MsgRecvPacket
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
-export interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeout {
-    type: string;
-    data: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutData;
-}
-interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutData {
-    packet: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutPacket;
-    proofUnreceived: string;
-    proofHeight: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight;
-    nextSequenceRecv: string;
+export interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeout
+  extends IRangeMessage {
+  type: Neutron1TrxMsgTypes.IbcCoreChannelV1MsgTimeout;
+  data: {
+    packet: {
+      data: string;
+      sequence: string;
+      sourcePort: string;
+      sourceChannel: string;
+      destinationPort: string;
+      destinationChannel: string;
+      timeoutHeight?: {
+        revisionHeight?: string;
+        revisionNumber?: string;
+      };
+      timeoutTimestamp?: string;
+    };
     signer: string;
+    proofHeight: {
+      revisionHeight?: string;
+      revisionNumber?: string;
+    };
+    proofUnreceived: string;
+    nextSequenceRecv: string;
+  };
 }
-interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutPacket {
-    sequence: string;
-    sourcePort: string;
-    sourceChannel: string;
-    destinationPort: string;
-    destinationChannel: string;
-    data: string;
-    timeoutHeight: Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight;
-}
-interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
 export interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClient


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgIbcCoreChannelV1MsgTimeout
    
**Block Data**
network: neutron-1
height: 5732377
