### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgIbcCoreClientV1MsgCreateClient

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -201,64 +201,66 @@ export interface Neutron1TrxMsgIbcCoreChannelV1MsgTimeout
 }
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
-export interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClient
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.IbcCoreClientV1MsgCreateClient;
-  data: {
-    '@type': string;
-    signer: string;
-    client_state: {
-      '@type': string;
-      chain_id: string;
-      proof_specs: {
-        leaf_spec: {
-          hash: string;
-          length: string;
-          prefix: string;
-          prehash_key: string;
-          prehash_value: string;
-        };
-        max_depth: number;
-        min_depth: number;
-        inner_spec: {
-          hash: string;
-          child_size: number;
-          child_order: number[];
-          empty_child?: unknown;
-          max_prefix_length: number;
-          min_prefix_length: number;
-        };
-        prehash_key_before_comparison: boolean;
-      }[];
-      trust_level: {
-        numerator: string;
-        denominator: string;
-      };
-      upgrade_path: string[];
-      frozen_height: {
-        revision_height: string;
-        revision_number: string;
-      };
-      latest_height: {
-        revision_height: string;
-        revision_number: string;
-      };
-      max_clock_drift: string;
-      trusting_period: string;
-      unbonding_period: string;
-      allow_update_after_expiry: boolean;
-      allow_update_after_misbehaviour: boolean;
-    };
-    consensus_state: {
-      root: {
-        hash: string;
-      };
-      '@type': string;
-      timestamp: string;
-      next_validators_hash: string;
-    };
-  };
+export interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClient {
+    type: string;
+    data: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientData;
 }
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientData {
+    clientState: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientClientState;
+    consensusState: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientConsensusState;
+    signer: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientClientState {
+    '@type': string;
+    chainId: string;
+    trustLevel: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientTrustLevel;
+    trustingPeriod: string;
+    unbondingPeriod: string;
+    maxClockDrift: string;
+    frozenHeight: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientFrozenHeight;
+    latestHeight: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientLatestHeight;
+    proofSpecs: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientProofSpecsItem[];
+    upgradePath: string[];
+    allowUpdateAfterExpiry: boolean;
+    allowUpdateAfterMisbehaviour: boolean;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientTrustLevel {
+    numerator: string;
+    denominator: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientFrozenHeight {
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientLatestHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientProofSpecsItem {
+    leafSpec: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientLeafSpec;
+    innerSpec: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientInnerSpec;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientLeafSpec {
+    hash: string;
+    prehashValue: string;
+    length: string;
+    prefix: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientInnerSpec {
+    childOrder: number[];
+    childSize: number;
+    minPrefixLength: number;
+    maxPrefixLength: number;
+    hash: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientConsensusState {
+    '@type': string;
+    timestamp: string;
+    root: Neutron1TrxMsgIbcCoreClientV1MsgCreateClientRoot;
+    nextValidatorsHash: string;
+}
+interface Neutron1TrxMsgIbcCoreClientV1MsgCreateClientRoot {
+    hash: string;
+}
+
 
 // types for mgs type:: ibc.core.client.v1.MsgUpdateClient
 export interface Neutron1TrxMsgIbcCoreClientV1MsgUpdateClient


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgIbcCoreClientV1MsgCreateClient
    
**Block Data**
network: neutron-1
height: 5974257
