### PR TITLE
[auto-fix] interface type created for Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -81,7 +81,7 @@ export enum Osmosis1TrxMsgTypes {
   CosmosBankV1beta1MsgUpdateParams = 'cosmos.bank.v1beta1.MsgUpdateParams',
   OsmosisTokenFactoryV1betaBurn = 'osmosis.tokenfactory.v1beta1.MsgBurn',
   OsmosisTokenFactoryV1beta1MsgChangeAdmin = 'osmosis.tokenfactory.v1beta1.MsgChangeAdmin',
-  OsmosisTokenFactoryV1beta1MsgSetDenomMetadata = 'osmosis.tokenfactory.v1beta1.MsgSetDenomMetadata',
+  OsmosisTokenfactoryV1beta1MsgSetDenomMetadata = 'osmosis.tokenfactory.v1beta1.MsgSetDenomMetadata',
 }
 
 export type Osmosis1TrxMsg =
@@ -165,7 +165,7 @@ export type Osmosis1TrxMsg =
   | Osmosis1TrxMsgCosmosBankV1beta1MsgUpdateParams
   | Osmosis1TrxMsgOsmosisTokenFactoryV1betaBurn
   | Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgChangeAdmin
-  | Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata;
+  | Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata;
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
 export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
@@ -1393,47 +1393,21 @@ export interface Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgChangeAdmin
 }
 
 // types for msg type:: /osmosis.tokenfactory.v1beta1.MsgChangeAdmin
-export interface Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata
+export interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata
   extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.OsmosisTokenFactoryV1beta1MsgSetDenomMetadata;
+  type: Osmosis1TrxMsgTypes.OsmosisTokenfactoryV1beta1MsgSetDenomMetadata;
   data: {
     sender: string;
     metadata: {
       description: string;
-      denom_units: {
+      denomUnits: {
         denom: string;
-        exponent: number;
-        aliases: string;
+        aliases: string[];
       }[];
       base: string;
       display: string;
       name: string;
       symbol: string;
-      uri: string;
-      uri_hash: string;
     };
   };
-}
-
-
-
-export interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata {
-    type: string;
-    data: Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataData;
-}
-interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataData {
-    sender: string;
-    metadata: Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataMetadata;
-}
-interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataMetadata {
-    description: string;
-    denomUnits: Osmosis1TrxMsgOsmosisTokenfactoryV1Beta1MsgSetDenomMetadataDenomUnitsItem[];
-    base: string;
-    display: string;
-    name: string;
-    symbol: string;
-}
-interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataDenomUnitsItem {
-    denom: string;
-    aliases: string[];
 }

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -1414,3 +1414,26 @@ export interface Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata
     };
   };
 }
+
+
+
+export interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata {
+    type: string;
+    data: Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataData;
+}
+interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataData {
+    sender: string;
+    metadata: Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataMetadata;
+}
+interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataMetadata {
+    description: string;
+    denomUnits: Osmosis1TrxMsgOsmosisTokenfactoryV1Beta1MsgSetDenomMetadataDenomUnitsItem[];
+    base: string;
+    display: string;
+    name: string;
+    symbol: string;
+}
+interface Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadataDenomUnitsItem {
+    denom: string;
+    aliases: string[];
+}


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type created for Osmosis1TrxMsgOsmosisTokenfactoryV1beta1MsgSetDenomMetadata
    
**Block Data**
network: osmosis-1
height: 15344315
