### PR TITLE
[auto-fix] interface type created for Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit

### DIFF
--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -577,3 +577,22 @@ export interface Noble1TrxMsgIbcCoreClientV1MsgUpdateClient
     };
   };
 }
+
+
+
+export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit {
+    type: string;
+    data: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData {
+    clientId: string;
+    counterparty: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty;
+    signer: string;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty {
+    clientId: string;
+    prefix: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix {
+    keyPrefix: string;
+}

--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -34,7 +34,7 @@ export type Noble1TrxMsg =
   | Noble1TrxMsgTypeMsgGrantAllowance
   | Noble1TrxMsgTypeMsgChannelOpenInit
   | Noble1TrxMsgTypeMsgConnectionOpenTry
-  | Noble1TrxMsgTypeMsgConnectionOpenInit
+  | Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit
   | Noble1TrxMsgTypeMsgTransfer
   | Noble1TrxMsgCosmosBankV1beta1MsgSend
   | Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
@@ -280,17 +280,18 @@ export interface Noble1TrxMsgTypeMsgConnectionOpenTry extends IRangeMessage {
 }
 
 // types for msg type:: /ibc.core.connection.v1.MsgConnectionOpenInit
-export interface Noble1TrxMsgTypeMsgConnectionOpenInit extends IRangeMessage {
+export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit
+  extends IRangeMessage {
   type: Noble1TrxMsgTypes.IbcCoreConnectionV1MsgConnectionOpenInit;
   data: {
-    signer: string;
-    client_id: string;
+    clientId: string;
     counterparty: {
+      clientId: string;
       prefix: {
         keyPrefix: string;
       };
-      client_id: string;
     };
+    signer: string;
   };
 }
 
@@ -576,23 +577,4 @@ export interface Noble1TrxMsgIbcCoreClientV1MsgUpdateClient
       };
     };
   };
-}
-
-
-
-export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit {
-    type: string;
-    data: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData;
-}
-interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData {
-    clientId: string;
-    counterparty: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty;
-    signer: string;
-}
-interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty {
-    clientId: string;
-    prefix: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix;
-}
-interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix {
-    keyPrefix: string;
 }


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type created for Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit
    
**Block Data**
network: noble-1
height: 6424430
