### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgement

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -430,32 +430,35 @@ export interface CosmosHub4TrxMsgIbcApplicationsTransferV1MsgTransfer
 }
 
 // types for msg type:: /ibc.core.channel.v1.MsgAcknowledgement
-export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgement
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.IbcCoreChannelV1MsgAcknowledgement;
-  data: {
-    packet: {
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      destinationPort: string;
-      destinationChannel: string;
-      data: string;
-      timeoutHeight: {
-        revisionNumber?: string;
-        revisionHeight?: string;
-      };
-      timeoutTimestamp?: string;
-    };
+export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgement {
+    type: string;
+    data: CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementData;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementData {
+    packet: CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementPacket;
     acknowledgement: string;
     proofAcked: string;
-    proofHeight: {
-      revisionNumber?: string;
-      revisionHeight?: string;
-    };
+    proofHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementProofHeight;
     signer: string;
-  };
 }
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementTimeoutHeight;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementTimeoutHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgementProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for msg type:: /ibc.core.channel.v1.MsgChannelCloseConfirm
 export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelCloseConfirm


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgAcknowledgement
    
**Block Data**
network: cosmoshub-4
height: 20754954
