### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -85,17 +85,28 @@ export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
-  };
+    grant: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    allowList: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAllowList;
+    authorizationType: string;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAllowList {
+    address: string[];
+}
+
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: cosmoshub-4
height: 20787899


**errors**
```
[
  {
    "path": "$input.transactions[6].messages[0].data.grant.authorization.allow_list",
    "expected": "__type.o6"
  },
  {
    "path": "$input.transactions[6].messages[0].data.grant.authorization.max_tokens",
    "expected": "null"
  },
  {
    "path": "$input.transactions[6].messages[0].data.grant.authorization.authorization_type",
    "expected": "string"
  }
]
```
      