### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeout

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -542,32 +542,34 @@ export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgRecvPacket
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
-export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeout
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.IbcCoreChannelV1MsgTimeout;
-  data: {
-    packet: {
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      destinationPort: string;
-      destinationChannel: string;
-      data: string;
-      timeoutHeight?: {
-        revisionNumber?: string;
-        revisionHeight?: string;
-      };
-      timeoutTimestamp?: string;
-    };
+export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeout {
+    type: string;
+    data: CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutData;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutData {
+    packet: CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutPacket;
     proofUnreceived: string;
-    proofHeight: {
-      revisionNumber?: string;
-      revisionHeight?: string;
-    };
+    proofHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight;
     nextSequenceRecv: string;
     signer: string;
-  };
 }
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight;
+    timeoutTimestamp: string;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight {
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
 export interface CosmosHub4TrxMsgIbcCoreClientV1MsgCreateClient


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgTimeout
    
**Block Data**
network: cosmoshub-4
height: 20800337


**errors**
```
[
  {
    "path": "$input.transactions[5].messages[1].data.packet.timeoutHeight.revisionHeight",
    "expected": "string"
  },
  {
    "path": "$input.transactions[5].messages[1].data.packet.timeoutHeight.revisionNumber",
    "expected": "string"
  }
]
```
      