### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -85,17 +85,24 @@ export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
-  };
+    grant: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    msg: string;
+}
+
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {

--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -85,24 +85,17 @@ export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant {
-    type: string;
-    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData;
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
+  extends IRangeMessage {
+  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
+  data: {
     granter: string;
     grantee: string;
-    grant: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
+    grant:
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
+  };
 }
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
-    authorization: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
-    expiration: string;
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
-    '@type': string;
-    msg: string;
-}
-
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {
@@ -111,13 +104,20 @@ interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization 
       address: string[];
     };
     authorizationType: string;
+    maxTokens?: {
+      denom: string;
+      amount: string;
+    };
   };
   expiration?: string;
 }
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization {
-  '@type': '/cosmos.authz.v1beta1.GenericAuthorization';
-  msg: string;
+  authorization: {
+    '@type': '/cosmos.authz.v1beta1.GenericAuthorization';
+    msg: string;
+  };
+  expiration: string;
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgRevoke


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: cosmoshub-4
height: 20831784


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[1].data.grant.authorization[\"@type\"]",
    "expected": "\"/cosmos.staking.v1beta1.StakeAuthorization\"",
    "value": "/cosmos.authz.v1beta1.GenericAuthorization"
  },
  {
    "path": "$input.transactions[0].messages[1].data.grant.authorization.allowList",
    "expected": "__type.o5"
  },
  {
    "path": "$input.transactions[0].messages[1].data.grant.authorization.authorizationType",
    "expected": "string"
  }
]
```
      