### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -561,31 +561,34 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgTimeout;
-  data: {
-    packet: {
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      destinationPort: string;
-      destinationChannel: string;
-      data: string;
-      timeoutHeight?: {
-        revisionNumber?: string;
-        revisionHeight?: string;
-      };
-    };
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout {
+    type: string;
+    data: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutData;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutData {
+    packet: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutPacket;
     proofUnreceived: string;
-    proofHeight?: {
-      revisionNumber?: string;
-      revisionHeight?: string;
-    };
+    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight;
     nextSequenceRecv: string;
     signer: string;
-  };
 }
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight;
+    timeoutTimestamp: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight {
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
 export interface Osmosis1TrxMsgIbcCoreClientV1MsgCreateClient

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -561,34 +561,32 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout {
-    type: string;
-    data: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutData;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutData {
-    packet: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutPacket;
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgTimeout;
+  data: {
+    packet: {
+      sequence: string;
+      sourcePort: string;
+      sourceChannel: string;
+      destinationPort: string;
+      destinationChannel: string;
+      data: string;
+      timeoutHeight?: {
+        revisionNumber?: string;
+        revisionHeight?: string;
+      };
+      timeoutTimestamp?: string;
+    };
     proofUnreceived: string;
-    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight;
+    proofHeight?: {
+      revisionNumber?: string;
+      revisionHeight?: string;
+    };
     nextSequenceRecv: string;
     signer: string;
+  };
 }
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutPacket {
-    sequence: string;
-    sourcePort: string;
-    sourceChannel: string;
-    destinationPort: string;
-    destinationChannel: string;
-    data: string;
-    timeoutHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight;
-    timeoutTimestamp: string;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutTimeoutHeight {
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeoutProofHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.client.v1.MsgCreateClient
 export interface Osmosis1TrxMsgIbcCoreClientV1MsgCreateClient


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout
    
**Block Data**
network: osmosis-1
height: 16671959


**errors**
```
[
  {
    "path": "$input.transactions[3].messages[1].data.packet.timeoutTimestamp",
    "expected": "undefined",
    "value": "1718197719630509497"
  }
]
```
      