### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -490,29 +490,34 @@ export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
-export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenTry;
-  data: {
-    portId: string;
-    signer: string;
-    channel: {
-      state: string;
-      version: string;
-      ordering: string;
-      counterparty: {
-        portId: string;
-        channelId: string;
-      };
-      connectionHops: string[];
-    };
-    proofInit: string;
-    proofHeight: {
-      revisionHeight: string;
-    };
-    counterpartyVersion: string;
-  };
+export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry {
+    type: string;
+    data: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryData;
 }
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryData {
+    portId: string;
+    channel: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel;
+    counterpartyVersion: string;
+    proofInit: string;
+    proofHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight;
+    signer: string;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel {
+    state: string;
+    ordering: string;
+    counterparty: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty;
+    connectionHops: string[];
+    version: string;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty {
+    portId: string;
+    channelId: string;
+}
+interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
 export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgRecvPacket

--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -490,34 +490,30 @@ export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenConfirm
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenTry
-export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry {
-    type: string;
-    data: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryData;
-}
-interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryData {
+export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry
+  extends IRangeMessage {
+  type: CosmosHub4TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenTry;
+  data: {
     portId: string;
-    channel: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel;
-    counterpartyVersion: string;
-    proofInit: string;
-    proofHeight: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight;
     signer: string;
+    channel: {
+      state: string;
+      version: string;
+      ordering: string;
+      counterparty: {
+        portId: string;
+        channelId: string;
+      };
+      connectionHops: string[];
+    };
+    proofInit: string;
+    proofHeight: {
+      revisionHeight: string;
+      revisionNumber?: string;
+    };
+    counterpartyVersion: string;
+  };
 }
-interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryChannel {
-    state: string;
-    ordering: string;
-    counterparty: CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty;
-    connectionHops: string[];
-    version: string;
-}
-interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryCounterparty {
-    portId: string;
-    channelId: string;
-}
-interface CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTryProofHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
 export interface CosmosHub4TrxMsgIbcCoreChannelV1MsgRecvPacket


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgIbcCoreChannelV1MsgChannelOpenTry
    
**Block Data**
network: cosmoshub-4
height: 20836994


**errors**
```
[
  {
    "path": "$input.transactions[7].messages[1].data.proofHeight.revisionNumber",
    "expected": "undefined",
    "value": "2"
  }
]
```
      