### PR TITLE
[auto-fix] interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -152,18 +152,24 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgExecDataMsgRevokeAllowance {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CelestiaTrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
-  };
+    grant: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    msg: string;
+}
+
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {

--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -152,24 +152,18 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgExecDataMsgRevokeAllowance {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant {
-    type: string;
-    data: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData {
+export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
+  extends IRangeMessage {
+  type: CelestiaTrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
+  data: {
     granter: string;
     grantee: string;
-    grant: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant;
+    grant:
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
+  };
 }
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant {
-    authorization: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
-    expiration: string;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
-    '@type': string;
-    msg: string;
-}
-
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {
@@ -197,6 +191,7 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization 
     '@type': '/cosmos.authz.v1beta1.GenericAuthorization';
     msg: string;
   };
+  expiration?: string;
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgRevoke


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: celestia
height: 1657578


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[0].data.grant.authorization[\"@type\"]",
    "expected": "\"/cosmos.staking.v1beta1.StakeAuthorization\"",
    "value": "/cosmos.authz.v1beta1.GenericAuthorization"
  },
  {
    "path": "$input.transactions[1].messages[0].data.grant.authorization.allowList",
    "expected": "__type.o12"
  },
  {
    "path": "$input.transactions[1].messages[0].data.grant.authorization.authorizationType",
    "expected": "string"
  },
  {
    "path": "$input.transactions[1].messages[0].data.grant.authorization.msg",
    "expected": "undefined",
    "value": "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward"
  }
]
```
      