### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -94,14 +94,20 @@ export interface Neutron1TrxMsgCosmwasmWasmV1MsgMigrateContract
 }
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgStoreCode
-export interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.CosmwasmWasmV1MsgStoreCode;
-  data: {
+export interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode {
+    type: string;
+    data: Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeData;
+}
+interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeData {
     sender: string;
     wasmByteCode: string;
-  };
+    instantiatePermission: Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission;
 }
+interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission {
+    permission: string;
+    addresses: string[];
+}
+
 
 // types for msg type:: /ibc.applications.transfer.v1.MsgTransfer
 export interface Neutron1TrxMsgIbcApplicationsTransferV1MsgTransfer

--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -94,20 +94,18 @@ export interface Neutron1TrxMsgCosmwasmWasmV1MsgMigrateContract
 }
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgStoreCode
-export interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode {
-    type: string;
-    data: Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeData;
-}
-interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeData {
+export interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode
+  extends IRangeMessage {
+  type: Neutron1TrxMsgTypes.CosmwasmWasmV1MsgStoreCode;
+  data: {
     sender: string;
     wasmByteCode: string;
-    instantiatePermission: Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission;
+    instantiatePermission?: {
+      permission: string;
+      addresses: string[];
+    };
+  };
 }
-interface Neutron1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission {
-    permission: string;
-    addresses: string[];
-}
-
 
 // types for msg type:: /ibc.applications.transfer.v1.MsgTransfer
 export interface Neutron1TrxMsgIbcApplicationsTransferV1MsgTransfer


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgStoreCode
    
**Block Data**
network: neutron-1
height: 11254100


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.instantiatePermission",
    "expected": "undefined",
    "value": {
      "permission": "ACCESS_TYPE_ANY_OF_ADDRESSES",
      "addresses": [
        "neutron1phx0sz708k3t6xdnyc98hgkyhra4tp44et5s68",
        "neutron13exc5wdc7y5qpqazc34djnu934lqvfw2dru30j52ahhjep6jzx8ssjxcyz"
      ]
    }
  }
]
```
      