### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -69,19 +69,18 @@ export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract
 }
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgInstantiateContract2
-export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2 {
-    type: string;
-    data: Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data;
-}
-interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data {
+export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2
+  extends IRangeMessage {
+  type: Neutron1TrxMsgTypes.CosmwasmWasmV1MsgInstantiateContract2;
+  data: {
     sender: string;
-    admin: string;
+    admin?: string;
     codeId: string;
     label: string;
     msg: string;
     salt: string;
+  };
 }
-
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgMigrateContract
 export interface Neutron1TrxMsgCosmwasmWasmV1MsgMigrateContract

--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -69,17 +69,19 @@ export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract
 }
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgInstantiateContract2
-export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.CosmwasmWasmV1MsgInstantiateContract2;
-  data: {
+export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2 {
+    type: string;
+    data: Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data;
+}
+interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data {
+    sender: string;
+    admin: string;
+    codeId: string;
+    label: string;
     msg: string;
     salt: string;
-    label: string;
-    codeId: string;
-    sender: string;
-  };
 }
+
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgMigrateContract
 export interface Neutron1TrxMsgCosmwasmWasmV1MsgMigrateContract


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2
    
**Block Data**
network: neutron-1
height: 11329614


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.admin",
    "expected": "undefined",
    "value": "neutron1u2qugkjaqmskx3fpmuh3a743wyxnwjqdgsyge6"
  }
]
```
      