### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgement

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -131,32 +131,33 @@ export interface Neutron1TrxMsgIbcApplicationsTransferV1MsgTransfer
 }
 
 // types for msg type:: /ibc.core.channel.v1.MsgAcknowledgement
-export interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgement
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.IbcCoreChannelV1MsgAcknowledgement;
-  data: {
-    packet: {
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      destinationPort: string;
-      destinationChannel: string;
-      data: string;
-      timeoutHeight?: {
-        revisionHeight: string;
-        revisionNumber?: string;
-      };
-      timeoutTimestamp?: string;
-    };
+export interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgement {
+    type: string;
+    data: Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementData;
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementData {
+    packet: Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementPacket;
     acknowledgement: string;
     proofAcked: string;
-    proofHeight: {
-      revisionHeight: string;
-      revisionNumber?: string;
-    };
+    proofHeight: Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementProofHeight;
     signer: string;
-  };
 }
+interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementTimeoutHeight;
+    timeoutTimestamp: string;
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementTimeoutHeight {
+}
+interface Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgementProofHeight {
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: ibc.core.channel.v1.MsgRecvPacket
 export interface Neutron1TrxMsgIbcCoreChannelV1MsgRecvPacket


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgIbcCoreChannelV1MsgAcknowledgement
    
**Block Data**
network: neutron-1
height: 11394063


**errors**
```
[
  {
    "path": "$input.transactions[2].messages[1].data.packet.timeoutHeight.revisionHeight",
    "expected": "string"
  }
]
```
      