### PR TITLE
[auto-fix] interface type updated for Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse

### DIFF
--- a/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
+++ b/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
@@ -380,27 +380,24 @@ export interface Stride1TrxMsgStrideClaimMsgClaimFreeAmount
 }
 
 // types for mgs type:: /stride.interchainquery.v1.MsgSubmitQueryResponse
-export interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse {
-    type: string;
-    data: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseData;
-}
-interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseData {
+export interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse
+  extends IRangeMessage {
+  type: Stride1TrxMsgTypes.StrideInterchainqueryV1MsgSubmitQueryResponse;
+  data: {
     chainId: string;
     queryId: string;
-    result: string;
-    proofOps: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseProofOps;
+    proofOps: {
+      ops: {
+        type: string;
+        key: string;
+        data: string;
+      }[];
+    };
     height: string;
     fromAddress: string;
+    result?: string;
+  };
 }
-interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseProofOps {
-    ops: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseOpsItem[];
-}
-interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseOpsItem {
-    type: string;
-    key: string;
-    data: string;
-}
-
 
 // types for mgs type:: /stride.stakeibc.MsgAddValidators
 export interface Stride1TrxMsgStrideStakeIBCMsgAddValidators

--- a/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
+++ b/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
@@ -380,23 +380,27 @@ export interface Stride1TrxMsgStrideClaimMsgClaimFreeAmount
 }
 
 // types for mgs type:: /stride.interchainquery.v1.MsgSubmitQueryResponse
-export interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse
-  extends IRangeMessage {
-  type: Stride1TrxMsgTypes.StrideInterchainqueryV1MsgSubmitQueryResponse;
-  data: {
+export interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse {
+    type: string;
+    data: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseData;
+}
+interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseData {
     chainId: string;
     queryId: string;
-    proofOps: {
-      ops: {
-        key: string;
-        data: string;
-        type: string;
-      }[];
-    };
+    result: string;
+    proofOps: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseProofOps;
     height: string;
     fromAddress: string;
-  };
 }
+interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseProofOps {
+    ops: Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseOpsItem[];
+}
+interface Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponseOpsItem {
+    type: string;
+    key: string;
+    data: string;
+}
+
 
 // types for mgs type:: /stride.stakeibc.MsgAddValidators
 export interface Stride1TrxMsgStrideStakeIBCMsgAddValidators


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Stride1TrxMsgStrideInterchainqueryV1MsgSubmitQueryResponse
    
**Block Data**
network: stride-1
height: 9506226


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[1].data.result",
    "expected": "undefined",
    "value": "MjkyNTM3MTQ2"
  },
  {
    "path": "$input.transactions[1].messages[1].data.result",
    "expected": "undefined",
    "value": "MjkyNTM3MTQ2"
  },
  {
    "path": "$input.transactions[3].messages[1].data.result",
    "expected": "undefined",
    "value": "MjkyNTM3MTQ2"
  }
]
```
      