### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -66,21 +66,21 @@ export enum CosmosHub4TrxMsgTypes {
 }
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgExec;
-  data: {
-    grantee: string;
-    msgs: (
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgDelegate
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgWithdrawDelegatorReward
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSetWithdrawAddress
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgMsgWithdrawValidatorCommission
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgVote
-    )[];
-  };
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData;
 }
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData {
+    grantee: string;
+    msgs: CosmosHub4TrxMsgCosmosAuthzV1Beta1MsgExecMsgsItem[];
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecMsgsItem {
+    '@type': string;
+    delegatorAddress?: string;
+    withdrawAddress?: string;
+    validatorAddress?: string;
+}
+
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend {
   '@type': '/cosmos.bank.v1beta1.MsgSend';

--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -66,21 +66,21 @@ export enum CosmosHub4TrxMsgTypes {
 }
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec {
-    type: string;
-    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData;
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
+  extends IRangeMessage {
+  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgExec;
+  data: {
     grantee: string;
-    msgs: CosmosHub4TrxMsgCosmosAuthzV1Beta1MsgExecMsgsItem[];
+    msgs: (
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgDelegate
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgWithdrawDelegatorReward
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSetWithdrawAddress
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgMsgWithdrawValidatorCommission
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgVote
+    )[];
+  };
 }
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecMsgsItem {
-    '@type': string;
-    delegatorAddress?: string;
-    withdrawAddress?: string;
-    validatorAddress?: string;
-}
-
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend {
   '@type': '/cosmos.bank.v1beta1.MsgSend';
@@ -111,7 +111,7 @@ interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgWithdrawDelega
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSetWithdrawAddress {
   '@type': '/cosmos.distribution.v1beta1.MsgSetWithdrawAddress';
   delegatorAddress: string;
-  validatorAddress: string;
+  withdrawAddress: string;
 }
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgMsgWithdrawValidatorCommission {


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
    
**Block Data**
network: cosmoshub-4
height: 20906565


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.msgs[0].validatorAddress",
    "expected": "string"
  },
  {
    "path": "$input.transactions[0].messages[0].data.msgs[2].validatorAddress",
    "expected": "string"
  }
]
```
      