### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -127,18 +127,28 @@ interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgVote {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization;
-  };
+    grant: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    spendLimit: CosmosHub4TrxMsgCosmosAuthzV1Beta1MsgGrantSpendLimitItem[];
+}
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantSpendLimitItem {
+    denom: string;
+    amount: string;
+}
+
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {

--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -127,36 +127,26 @@ interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgVote {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant {
-    type: string;
-    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData;
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantData {
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
+  extends IRangeMessage {
+  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
+  data: {
     granter: string;
     grantee: string;
-    grant: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
+    grant:
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization
+      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization;
+  };
 }
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
-    authorization: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
-    expiration: string;
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
-    '@type': string;
-    spendLimit: CosmosHub4TrxMsgCosmosAuthzV1Beta1MsgGrantSpendLimitItem[];
-}
-interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantSpendLimitItem {
-    denom: string;
-    amount: string;
-}
-
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {
     '@type': '/cosmos.staking.v1beta1.StakeAuthorization';
-    allowList: {
+    authorizationType: string;
+    allowList?: {
       address: string[];
     };
-    authorizationType: string;
     maxTokens?: {
       denom: string;
       amount: string;
@@ -170,14 +160,14 @@ interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorizatio
     '@type': '/cosmos.authz.v1beta1.GenericAuthorization';
     msg: string;
   };
-  expiration: string;
+  expiration?: string;
 }
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {
     '@type': '/cosmos.bank.v1beta1.SendAuthorization';
     spendLimit: { denom: string; amount: string }[];
-  }[];
+  };
   expiration: string;
 }
 


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: cosmoshub-4
height: 20918504


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[1].data.grant",
    "expected": "(CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization)",
    "value": {
      "authorization": {
        "@type": "/cosmos.bank.v1beta1.SendAuthorization",
        "spendLimit": [
          {
            "denom": "uatom",
            "amount": "1000000000000"
          }
        ]
      },
      "expiration": "2027-06-19T12:49:38Z"
    }
  }
]
```
      