### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -659,21 +659,19 @@ export interface Osmosis1TrxMsgIbcCoreClientV1MsgUpdateClient
 }
 
 // types for mgs type:: /ibc.core.connection.v1.MsgConnectionOpenConfirm
-export interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm {
-    type: string;
-    data: Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmData;
-}
-interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmData {
+export interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcCoreConnectionV1MsgConnectionOpenConfirm;
+  data: {
     connectionId: string;
     proofAck: string;
-    proofHeight: Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmProofHeight;
+    proofHeight: {
+      revisionNumber?: string;
+      revisionHeight: string;
+    };
     signer: string;
+  };
 }
-interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmProofHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /osmosis.concentratedliquidity.poolmodel.concentrated.v1beta1.MsgCreateConcentratedPool
 export interface Osmosis1TrxMsgOsmosisConcentratedliquidityPoolModelConcentratedV1beta1MsgCreateConcentratedPool

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -659,18 +659,21 @@ export interface Osmosis1TrxMsgIbcCoreClientV1MsgUpdateClient
 }
 
 // types for mgs type:: /ibc.core.connection.v1.MsgConnectionOpenConfirm
-export interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcCoreConnectionV1MsgConnectionOpenConfirm;
-  data: {
-    signer: string;
-    proofAck: string;
-    proofHeight: {
-      revisionHeight: string;
-    };
-    connectionId: string;
-  };
+export interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm {
+    type: string;
+    data: Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmData;
 }
+interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmData {
+    connectionId: string;
+    proofAck: string;
+    proofHeight: Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmProofHeight;
+    signer: string;
+}
+interface Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirmProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /osmosis.concentratedliquidity.poolmodel.concentrated.v1beta1.MsgCreateConcentratedPool
 export interface Osmosis1TrxMsgOsmosisConcentratedliquidityPoolModelConcentratedV1beta1MsgCreateConcentratedPool


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcCoreConnectionV1MsgConnectionOpenConfirm
    
**Block Data**
network: osmosis-1
height: 16961862


**errors**
```
[
  {
    "path": "$input.transactions[4].messages[1].data.proofHeight.revisionNumber",
    "expected": "undefined",
    "value": "1"
  }
]
```
      