### PR TITLE
[auto-fix] interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -163,33 +163,18 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgExecDataMsgMsgDelegate {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant {
-    type: string;
-    data: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData {
+export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
+  extends IRangeMessage {
+  type: CelestiaTrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
+  data: {
     granter: string;
     grantee: string;
-    grant: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant;
+    grant:
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
+      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
+  };
 }
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant {
-    authorization: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
-    expiration: string;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
-    '@type': string;
-    maxTokens: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantMaxTokens;
-    allowList: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAllowList;
-    authorizationType: string;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantMaxTokens {
-    denom: string;
-    amount: string;
-}
-interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAllowList {
-    address: string[];
-}
-
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {
@@ -198,12 +183,17 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
       denom: string;
       amount: string;
     }[];
+    expiration?: string;
   };
 }
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization {
   authorization: {
     '@type': '/cosmos.staking.v1beta1.StakeAuthorization';
+    maxTokens?: {
+      denom: string;
+      amount: string;
+    };
     allowList: {
       address: string[];
     };

--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -163,18 +163,33 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgExecDataMsgMsgDelegate {
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CelestiaTrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
-  };
+    grant: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    maxTokens: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantMaxTokens;
+    allowList: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAllowList;
+    authorizationType: string;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantMaxTokens {
+    denom: string;
+    amount: string;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAllowList {
+    address: string[];
+}
+
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: celestia
height: 1786814


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[0].data.grant.authorization.maxTokens",
    "expected": "undefined",
    "value": {
      "denom": "utia",
      "amount": "100000"
    }
  }
]
```
      