### PR TITLE
[auto-fix] interface type updated for Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck

### DIFF
--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -366,19 +366,24 @@ export interface Noble1TrxMsgCosmosBankV1beta1MsgSend extends IRangeMessage {
 }
 
 // types for msg type:: /ibc.core.channel.v1.MsgChannelOpenAck
-export interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
-  extends IRangeMessage {
-  type: Noble1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenAck;
-  data: {
-    portId: string;
-    signer: string;
-    proofTry: string;
-    channelId: string;
-    proofHeight: { revisionHeight: string };
-    counterpartyVersion: string;
-    counterpartyChannelId: string;
-  };
+export interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck {
+    type: string;
+    data: Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData;
 }
+interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData {
+    portId: string;
+    channelId: string;
+    counterpartyChannelId: string;
+    counterpartyVersion: string;
+    proofTry: string;
+    proofHeight: Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight;
+    signer: string;
+}
+interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+
 
 // types for msg type:: /noble.fiattokenfactory.MsgMint
 export interface Noble1TrxMsgNobleFiatTokenFactoryMsgMint

--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -366,24 +366,22 @@ export interface Noble1TrxMsgCosmosBankV1beta1MsgSend extends IRangeMessage {
 }
 
 // types for msg type:: /ibc.core.channel.v1.MsgChannelOpenAck
-export interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck {
-    type: string;
-    data: Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData;
-}
-interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData {
+export interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
+  extends IRangeMessage {
+  type: Noble1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenAck;
+  data: {
     portId: string;
-    channelId: string;
-    counterpartyChannelId: string;
-    counterpartyVersion: string;
-    proofTry: string;
-    proofHeight: Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight;
     signer: string;
+    proofTry: string;
+    channelId: string;
+    proofHeight: {
+      revisionHeight: string;
+      revisionNumber?: string;
+    };
+    counterpartyVersion: string;
+    counterpartyChannelId: string;
+  };
 }
-interface Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-
 
 // types for msg type:: /noble.fiattokenfactory.MsgMint
 export interface Noble1TrxMsgNobleFiatTokenFactoryMsgMint


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Noble1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
    
**Block Data**
network: noble-1
height: 7597739


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[1].data.proofHeight.revisionNumber",
    "expected": "undefined",
    "value": "10"
  }
]
```
      