### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -168,13 +168,14 @@ export type Osmosis1TrxMsg =
   | Osmosis1TrxMsgOsmosisTokenFactoryV1beta1MsgSetDenomMetadata;
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.CosmosAuthzV1beta1MsgExec;
-  data: {
-    grantee: string;
-    msgs: unknown[];
-  };
+export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec {
+    type: string;
+    data: Osmosis1TrxMsgCosmosAuthzV1beta1MsgExecData;
 }
+interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExecData {
+    error: string;
+}
+
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgGrant
 export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrant


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec
    
**Block Data**
network: osmosis-1
height: 17521895


**errors**
```
[
  {
    "path": "$input.transactions[3].messages[0].data.grantee",
    "expected": "string"
  },
  {
    "path": "$input.transactions[3].messages[0].data.msgs",
    "expected": "Array<unknown>"
  },
  {
    "path": "$input.transactions[3].messages[0].data.error",
    "expected": "undefined",
    "value": "unable to resolve /sdk.auction.v1.MsgAuctionBid: not found"
  }
]
```
      