### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -416,14 +416,20 @@ export interface Osmosis1TrxMsgCosmwasmWasmV1MsgMigrateContract
 }
 
 // types for mgs type:: /cosmwasm.wasm.v1.MsgStoreCode
-export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.CosmwasmWasmV1MsgStoreCode;
-  data: {
+export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode {
+    type: string;
+    data: Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeData;
+}
+interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeData {
     sender: string;
     wasmByteCode: string;
-  };
+    instantiatePermission: Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission;
 }
+interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission {
+    permission: string;
+    addresses: string[];
+}
+
 
 // types for mgs type:: /ibc.applications.transfer.v1.MsgTransfer
 export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -416,20 +416,18 @@ export interface Osmosis1TrxMsgCosmwasmWasmV1MsgMigrateContract
 }
 
 // types for mgs type:: /cosmwasm.wasm.v1.MsgStoreCode
-export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode {
-    type: string;
-    data: Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeData;
-}
-interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeData {
+export interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.CosmwasmWasmV1MsgStoreCode;
+  data: {
     sender: string;
     wasmByteCode: string;
-    instantiatePermission: Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission;
+    instantiatePermission?: {
+      permission: string;
+      addresses: string[];
+    };
+  };
 }
-interface Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCodeInstantiatePermission {
-    permission: string;
-    addresses: string[];
-}
-
 
 // types for mgs type:: /ibc.applications.transfer.v1.MsgTransfer
 export interface Osmosis1TrxMsgIbcApplicationsTransferV1MsgTransfer


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgCosmwasmWasmV1MsgStoreCode
    
**Block Data**
network: osmosis-1
height: 17639376


**errors**
```
[
  {
    "path": "$input.transactions[2].messages[0].data.instantiatePermission",
    "expected": "undefined",
    "value": {
      "permission": "ACCESS_TYPE_ANY_OF_ADDRESSES",
      "addresses": [
        "osmo1n7t0jxal09tayv6tm000lp7dw47cje5qwe5wjc"
      ]
    }
  }
]
```
      