### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -1163,31 +1163,39 @@ export interface Osmosis1TrxMsgOsmosisValsetprefV1beta1MsgWithdrawDelegationRewa
 }
 
 // types for mgs type:: /cosmos.staking.v1beta1.MsgCreateValidator
-export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.CosmosStakingV1beta1MsgCreateValidator;
-  data: {
-    description: {
-      details?: string;
-      moniker: string;
-      identity?: string;
-      securityContact?: string;
-    };
-    commission: {
-      rate: string;
-      maxRate: string;
-      maxChangeRate: string;
-    };
+export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator {
+    type: string;
+    data: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData {
+    description: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription;
+    commission: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission;
     minSelfDelegation: string;
     delegatorAddress: string;
     validatorAddress: string;
-    pubkey: {
-      key: string;
-      '@type': string;
-    };
-    value: { denom: string; amount: string };
-  };
+    pubkey: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey;
+    value: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue;
 }
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription {
+    moniker: string;
+    website: string;
+    securityContact: string;
+    details: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission {
+    rate: string;
+    maxRate: string;
+    maxChangeRate: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey {
+    '@type': string;
+    key: string;
+}
+interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue {
+    denom: string;
+    amount: string;
+}
+
 
 // types for mgs type:: /cosmos.distribution.v1beta1.MsgFundCommunityPool
 export interface Osmosis1TrxMsgCosmosDistributionV1beta1MsgFundCommunityPool

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -1163,39 +1163,35 @@ export interface Osmosis1TrxMsgOsmosisValsetprefV1beta1MsgWithdrawDelegationRewa
 }
 
 // types for mgs type:: /cosmos.staking.v1beta1.MsgCreateValidator
-export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator {
-    type: string;
-    data: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorData {
-    description: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription;
-    commission: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission;
+export interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.CosmosStakingV1beta1MsgCreateValidator;
+  data: {
+    description: {
+      moniker?: string;
+      identity?: string;
+      website?: string;
+      details?: string;
+      securityContact?: string;
+    };
+    commission: {
+      rate: string;
+      maxRate: string;
+      maxChangeRate: string;
+    };
     minSelfDelegation: string;
     delegatorAddress: string;
     validatorAddress: string;
-    pubkey: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey;
-    value: Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue;
+    pubkey: {
+      '@type': string;
+      key: string;
+    };
+    value: {
+      denom: string;
+      amount: string;
+    };
+  };
 }
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorDescription {
-    moniker: string;
-    website: string;
-    securityContact: string;
-    details: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorCommission {
-    rate: string;
-    maxRate: string;
-    maxChangeRate: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorPubkey {
-    '@type': string;
-    key: string;
-}
-interface Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidatorValue {
-    denom: string;
-    amount: string;
-}
-
 
 // types for mgs type:: /cosmos.distribution.v1beta1.MsgFundCommunityPool
 export interface Osmosis1TrxMsgCosmosDistributionV1beta1MsgFundCommunityPool


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgCosmosStakingV1beta1MsgCreateValidator
    
**Block Data**
network: osmosis-1
height: 17839267


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[0].data.description.website",
    "expected": "undefined",
    "value": "https://test"
  }
]
```
      