### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -551,33 +551,31 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket {
-    type: string;
-    data: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketData;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketData {
-    packet: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketPacket;
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket
+  extends IRangeMessage {
+  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgRecvPacket;
+  data: {
+    packet: {
+      sequence: string;
+      sourcePort: string;
+      sourceChannel: string;
+      destinationPort: string;
+      destinationChannel: string;
+      data: string;
+      timeoutTimestamp?: string;
+      timeoutHeight?: {
+        revisionNumber?: string;
+        revisionHeight?: string;
+      };
+    };
     proofCommitment: string;
-    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketProofHeight;
+    proofHeight: {
+      revisionNumber?: string;
+      revisionHeight: string;
+    };
     signer: string;
+  };
 }
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketPacket {
-    sequence: string;
-    sourcePort: string;
-    sourceChannel: string;
-    destinationPort: string;
-    destinationChannel: string;
-    data: string;
-    timeoutHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketTimeoutHeight;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketTimeoutHeight {
-    revisionNumber: string;
-    revisionHeight: string;
-}
-interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketProofHeight {
-    revisionHeight: string;
-}
-
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout

--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -551,31 +551,33 @@ export interface Osmosis1TrxMsgIbcCoreChannelV1MsgChannelOpenTry
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
-export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.IbcCoreChannelV1MsgRecvPacket;
-  data: {
-    packet: {
-      sequence: string;
-      sourcePort: string;
-      sourceChannel: string;
-      destinationPort: string;
-      destinationChannel: string;
-      data: string;
-      timeoutTimestamp?: string;
-      timeoutHeight?: {
-        revisionNumber?: string;
-        revisionHeight?: string;
-      };
-    };
-    proofCommitment: string;
-    proofHeight: {
-      revisionNumber: string;
-      revisionHeight: string;
-    };
-    signer: string;
-  };
+export interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket {
+    type: string;
+    data: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketData;
 }
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketData {
+    packet: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketPacket;
+    proofCommitment: string;
+    proofHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketProofHeight;
+    signer: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketPacket {
+    sequence: string;
+    sourcePort: string;
+    sourceChannel: string;
+    destinationPort: string;
+    destinationChannel: string;
+    data: string;
+    timeoutHeight: Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketTimeoutHeight;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketTimeoutHeight {
+    revisionNumber: string;
+    revisionHeight: string;
+}
+interface Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacketProofHeight {
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgTimeout
 export interface Osmosis1TrxMsgIbcCoreChannelV1MsgTimeout


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgIbcCoreChannelV1MsgRecvPacket
    
**Block Data**
network: osmosis-1
height: 18066505


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[1].data.proofHeight.revisionNumber",
    "expected": "string"
  }
]
```
      