### PR TITLE
[auto-fix] interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
+++ b/src/types/chain/celestia/IRangeBlockCelestiaTrxMsg.ts
@@ -194,18 +194,28 @@ interface CelestiaTrxMsgCosmosAuthzV1beta1MsgExecDataMsgMsgWithdrawValidatorComm
 }
 
 // types for msg type:: /cosmos.authz.v1beta1.MsgGrant
-export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: CelestiaTrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization
-      | CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization;
-  };
+    grant: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+    expiration: string;
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    spendLimit: CelestiaTrxMsgCosmosAuthzV1Beta1MsgGrantSpendLimitItem[];
+}
+interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantSpendLimitItem {
+    denom: string;
+    amount: string;
+}
+
 
 interface CelestiaTrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization {
   authorization: {


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CelestiaTrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: celestia
height: 1919803


**errors**
```
[
  {
    "path": "$input.transactions[2].messages[0].data.grant.expiration",
    "expected": "undefined",
    "value": "2025-07-05T00:00:00Z"
  }
]
```
      