### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -66,24 +66,14 @@ export enum CosmosHub4TrxMsgTypes {
 }
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgExec
-export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
-  extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosAuthzV1beta1MsgExec;
-  data: {
-    grantee: string;
-    msgs: (
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgDelegate
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgUndelegate
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgWithdrawDelegatorReward
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSetWithdrawAddress
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgMsgWithdrawValidatorCommission
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgVote
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgGrant
-      | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgRevoke
-    )[];
-  };
+export interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData;
 }
+interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecData {
+    error: string;
+}
+
 
 interface CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend {
   '@type': '/cosmos.bank.v1beta1.MsgSend';


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExec
    
**Block Data**
network: cosmoshub-4
height: 21383786


**errors**
```
[
  {
    "path": "$input.transactions[4].messages[0].data.grantee",
    "expected": "string"
  },
  {
    "path": "$input.transactions[4].messages[0].data.msgs",
    "expected": "Array<CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgSend | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgDelegate | ... 6 more ... | CosmosHub4TrxMsgCosmosAuthzV1beta1MsgExecDataMsgsTypeMsgRevoke>"
  },
  {
    "path": "$input.transactions[4].messages[0].data.error",
    "expected": "undefined",
    "value": "unable to resolve /cosmos.staking.v1beta1.MsgTokenizeShares: not found"
  }
]
```
      