### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgOsmosisIncentivesMsgCreateGauge

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -954,26 +954,27 @@ export interface Osmosis1TrxMsgOsmosisIncentivesMsgAddToGauge
 }
 
 // types for mgs type:: /osmosis.incentives.MsgCreateGauge
-export interface Osmosis1TrxMsgOsmosisIncentivesMsgCreateGauge
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.OsmosisIncentivesMsgCreateGauge;
-  data: {
+export interface Osmosis1TrxMsgOsmosisIncentivesMsgCreateGauge {
+    type: string;
+    data: Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeData;
+}
+interface Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeData {
     owner: string;
-    distributeTo: {
-      lockQueryType: string;
-      denom?: string;
-      duration: string;
-      timestamp: string;
-    };
-    coins: {
-      denom: string;
-      amount: string;
-    }[];
+    distributeTo: Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeDistributeTo;
+    coins: Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeCoinsItem[];
     startTime: string;
     numEpochsPaidOver: string;
-    poolId: string;
-  };
 }
+interface Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeDistributeTo {
+    denom: string;
+    duration: string;
+    timestamp: string;
+}
+interface Osmosis1TrxMsgOsmosisIncentivesMsgCreateGaugeCoinsItem {
+    denom: string;
+    amount: string;
+}
+
 
 // types for mgs type:: /osmosis.lockup.MsgBeginUnlocking
 export interface Osmosis1TrxMsgOsmosisLockupMsgBeginUnlocking


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgOsmosisIncentivesMsgCreateGauge
    
**Block Data**
network: osmosis-1
height: 18270380


**errors**
```
[
  {
    "path": "$input.transactions[3].messages[0].data.distributeTo.lockQueryType",
    "expected": "string"
  },
  {
    "path": "$input.transactions[3].messages[0].data.poolId",
    "expected": "string"
  }
]
```
      