### PR TITLE
[auto-fix] interface type updated for Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAck

### DIFF
--- a/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
+++ b/src/types/chain/stride-1/IRangeBlockStride1TrxMsg.ts
@@ -301,22 +301,23 @@ export interface Stride1TrxMsgIbcCoreChannelV1MsgAcknowledgement
 }
 
 // types for mgs type:: /ibc.core.channel.v1.MsgChannelOpenAck
-export interface Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
-  extends IRangeMessage {
-  type: Stride1TrxMsgTypes.IbcCoreChannelV1MsgChannelOpenAck;
-  data: {
+export interface Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAck {
+    type: string;
+    data: Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData;
+}
+interface Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAckData {
     portId: string;
     channelId: string;
     counterpartyChannelId: string;
     counterpartyVersion: string;
     proofTry: string;
-    proofHeight: {
-      revisionNumber: string;
-      revisionHeight: string;
-    };
+    proofHeight: Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight;
     signer: string;
-  };
 }
+interface Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAckProofHeight {
+    revisionHeight: string;
+}
+
 
 // types for mgs type:: /ibc.core.channel.v1.MsgRecvPacket
 export interface Stride1TrxMsgIbcCoreChannelV1MsgRecvPacket


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Stride1TrxMsgIbcCoreChannelV1MsgChannelOpenAck
    
**Block Data**
network: stride-1
height: 10056728


**errors**
```
[
  {
    "path": "$input.transactions[3].messages[1].data.proofHeight.revisionNumber",
    "expected": "string"
  }
]
```
      