### PR TITLE
[auto-fix] interface type updated for Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit

### DIFF
--- a/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
+++ b/src/types/chain/noble-1/IRangeBlockNoble1TrxMsg.ts
@@ -318,20 +318,28 @@ export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenTry
 }
 
 // types for msg type:: /ibc.core.connection.v1.MsgConnectionOpenInit
-export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit
-  extends IRangeMessage {
-  type: Noble1TrxMsgTypes.IbcCoreConnectionV1MsgConnectionOpenInit;
-  data: {
-    clientId: string;
-    counterparty: {
-      clientId: string;
-      prefix: {
-        keyPrefix: string;
-      };
-    };
-    signer: string;
-  };
+export interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit {
+    type: string;
+    data: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData;
 }
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitData {
+    clientId: string;
+    counterparty: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty;
+    version: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitVersion;
+    signer: string;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitCounterparty {
+    clientId: string;
+    prefix: Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitPrefix {
+    keyPrefix: string;
+}
+interface Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInitVersion {
+    identifier: string;
+    features: string[];
+}
+
 
 // types for msg type:: /ibc.applications.transfer.v1.MsgTransfer
 export interface Noble1TrxMsgIbcApplicationsTransferV1MsgTransfer


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Noble1TrxMsgIbcCoreConnectionV1MsgConnectionOpenInit
    
**Block Data**
network: noble-1
height: 8896922


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.version",
    "expected": "undefined",
    "value": {
      "identifier": "1",
      "features": [
        "ORDER_ORDERED",
        "ORDER_UNORDERED"
      ]
    }
  }
]
```
      