### PR TITLE
[auto-fix] interface type updated for Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrant

### DIFF
--- a/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
+++ b/src/types/chain/osmosis-1/IRangeBlockOsmosis1TrxMsg.ts
@@ -177,18 +177,23 @@ export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgExec extends IRangeMessage {
 }
 
 // types for mgs type:: /cosmos.authz.v1beta1.MsgGrant
-export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrant
-  extends IRangeMessage {
-  type: Osmosis1TrxMsgTypes.CosmosAuthzV1beta1MsgGrant;
-  data: {
+export interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrant {
+    type: string;
+    data: Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantData;
+}
+interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantData {
     granter: string;
     grantee: string;
-    grant:
-      | Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization
-      | Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization
-      | Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization;
-  };
+    grant: Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantGrant;
 }
+interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantGrant {
+    authorization: Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization;
+}
+interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantAuthorization {
+    '@type': string;
+    msg: string;
+}
+
 
 interface Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization {
   authorization: {


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrant
    
**Block Data**
network: osmosis-1
height: 18521078


**errors**
```
[
  {
    "path": "$input.transactions[1].messages[0].data.grant",
    "expected": "(Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantGenericAuthorization | Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantSendAuthorization | Osmosis1TrxMsgCosmosAuthzV1beta1MsgGrantDataGrantStakeAuthorization)",
    "value": {
      "authorization": {
        "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
        "msg": "/cosmwasm.wasm.v1.MsgExecuteContract"
      }
    }
  }
]
```
      