### PR TITLE
[auto-fix] interface type updated for CosmosHub4TrxMsgCosmosGovV1beta1MsgVote

### DIFF
--- a/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
+++ b/src/types/chain/cosmoshub-4/IRangeBlockCosmosHub4TrxMsg.ts
@@ -373,14 +373,15 @@ interface CosmosHub4TrxMsgCosmosGovV1beta1MsgSubmitProposalDataContentTypeClient
 }
 
 // types for msg type:: /cosmos.gov.v1beta1.MsgVote
-export interface CosmosHub4TrxMsgCosmosGovV1beta1MsgVote extends IRangeMessage {
-  type: CosmosHub4TrxMsgTypes.CosmosGovV1beta1MsgVote;
-  data: {
+export interface CosmosHub4TrxMsgCosmosGovV1beta1MsgVote {
+    type: string;
+    data: CosmosHub4TrxMsgCosmosGovV1beta1MsgVoteData;
+}
+interface CosmosHub4TrxMsgCosmosGovV1beta1MsgVoteData {
     voter: string;
     option: string;
-    proposalId: string;
-  };
 }
+
 
 // types for msg type:: /cosmos.gov.v1beta1.MsgVoteWeighted
 export interface CosmosHub4TrxMsgCosmosGovV1beta1MsgVoteWeighted


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for CosmosHub4TrxMsgCosmosGovV1beta1MsgVote
    
**Block Data**
network: cosmoshub-4
height: 21557203


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.proposalId",
    "expected": "string"
  }
]
```
      