### PR TITLE
[auto-fix] interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2

### DIFF
--- a/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
+++ b/src/types/chain/neutron-1/IRangeBlockNeutron1TrxMsg.ts
@@ -74,18 +74,24 @@ export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract
 }
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgInstantiateContract2
-export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2
-  extends IRangeMessage {
-  type: Neutron1TrxMsgTypes.CosmwasmWasmV1MsgInstantiateContract2;
-  data: {
+export interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2 {
+    type: string;
+    data: Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data;
+}
+interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2Data {
     sender: string;
-    admin?: string;
+    admin: string;
     codeId: string;
     label: string;
     msg: string;
+    funds: Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2FundsItem[];
     salt: string;
-  };
 }
+interface Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2FundsItem {
+    denom: string;
+    amount: string;
+}
+
 
 // types for msg type:: /cosmwasm.wasm.v1.MsgMigrateContract
 export interface Neutron1TrxMsgCosmwasmWasmV1MsgMigrateContract


### PR DESCRIPTION
**This is an automated generated pr**
**changelog**
- auto-fix: interface type updated for Neutron1TrxMsgCosmwasmWasmV1MsgInstantiateContract2
    
**Block Data**
network: neutron-1
height: 13158365


**errors**
```
[
  {
    "path": "$input.transactions[0].messages[0].data.funds",
    "expected": "undefined",
    "value": [
      {
        "denom": "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81",
        "amount": "10000000"
      },
      {
        "denom": "untrn",
        "amount": "11000000"
      }
    ]
  }
]
```
      